### PR TITLE
Use JWT token instead of cookie for managing auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ export default defineNuxtConfig({
     // ...
   ],
   nuxtSanctumAuth: {
+    token: false, // set true to use jwt-token auth instead of cookie. default is false
     baseUrl: 'http://localhost:8000',
     endpoints: {
       csrf: '/sanctum/csrf-cookie',
@@ -72,7 +73,7 @@ const { $sanctumAuth } = useNuxtApp()
 const router = useRouter()
 const errors = ref([])
 
-async function login () => {
+async function login () {
   try {
     await $sanctumAuth.login(
       {
@@ -126,11 +127,11 @@ const { user, loggedIn } = useState('auth').value
 <template>
   <div>
     Is user logged in?
-    <sapn>{{ loggedIn ? 'yes' : 'no' }}</sapn>
+    <span>{{ loggedIn ? 'yes' : 'no' }}</span>
   </div>
   <div v-if="loggedIn">
     What is users name?
-    <sapn>{{ user.name }}</sapn>
+    <span>{{ user.name }}</span>
   </div>
 </template>
 ```
@@ -160,9 +161,42 @@ definePageMeta({
 </script>
 ```
 
+### Using JWT-token auth instead of cookie
+
+If you want to use Laravel Sanctum with JWT token authentication method,
+set the `token` property to true in the module configuration.
+```js
+nuxtSanctumAuth: {
+    token: true
+    // other properties
+  }
+```
+Your Laravel backend should respond on the login endpoint with a json containing property `token`:
+```json
+{
+  "token": "1|p1tEPICErFs9TpGKjfkz5QcWDi5M4YqJpVLGUwqM"
+}
+```
+
+Once logged in, the token will be saved in a cookie.
+
+If you need to access the token, use property of `useState('auth')`
+```vue
+<script setup>
+const { token } = useState('auth').value
+</script>
+
+<template>
+  <div>
+    What is auth jwt token?
+    <span>{{ token }}</span>
+  </div>
+</template>
+```
+
 ### Data fetching
 
-In guarded pages, you will have to use special fetching method inside `useAsyncData`. This methods is responsible for carrying the XSRF token.
+In guarded pages, you will have to use special fetching method inside `useAsyncData`. This methods is responsible for carrying the XSRF or JWT auth token.
 
 ```vue
 <script setup>

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -17,6 +17,7 @@ export default defineNuxtConfig({
   modules: [nuxtSanctumAuth, '@nuxtjs/tailwindcss'],
 
   nuxtSanctumAuth: {
+    token: false, // set true to test jwt-token auth instead of cookie
     baseUrl: 'http://localhost:8000',
     endpoints: {
       csrf: '/sanctum/csrf-cookie',

--- a/playground/pages/account/index.vue
+++ b/playground/pages/account/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { definePageMeta, useNuxtApp, useState } from '#imports'
+import { definePageMeta, useAuth, useNuxtApp, useState } from '#imports'
 definePageMeta({
   middleware: ['auth']
 })
@@ -10,7 +10,7 @@ interface Auth {
 }
 
 const { $sanctumAuth } = useNuxtApp()
-const auth = useState<Auth>('auth').value
+const auth = useAuth()
 const logout = async () => {
   await $sanctumAuth.logout()
 }

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -1,14 +1,9 @@
 <script setup lang="ts">
-import { useState, ref, computed, onMounted, useNuxtApp } from '#imports'
-
-interface Auth {
-  user: any
-  loggedIn: boolean
-}
+import { ref, onMounted, useNuxtApp, useAuth } from '#imports'
 
 const { $sanctumAuth } = useNuxtApp()
 const loading = ref(true)
-const auth = computed(() => useState<Auth>('auth').value)
+const auth = useAuth()
 
 onMounted(async () => {
   await $sanctumAuth.getUser()

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,4 @@
-import { defineNuxtModule, createResolver, addPlugin } from '@nuxt/kit'
+import { defineNuxtModule, createResolver, addPlugin, addImports } from '@nuxt/kit'
 import { ModuleOptions } from './types'
 
 const defaults: ModuleOptions = {
@@ -27,5 +27,12 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.runtimeConfig.public.nuxtSanctumAuth = options
     const { resolve } = createResolver(import.meta.url)
     addPlugin(resolve('./runtime/plugin'))
+
+    addImports({
+      name: 'useAuth',
+      as: 'useAuth',
+      from: resolve('runtime/composables')
+    })
+
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,8 @@
-import { defineNuxtModule, addPlugin, createResolver } from '@nuxt/kit'
+import { defineNuxtModule, createResolver, addPlugin } from '@nuxt/kit'
 import { ModuleOptions } from './types'
 
 const defaults: ModuleOptions = {
+  token: false,
   baseUrl: 'http://localhost:8000',
   endpoints: {
     csrf: '/sanctum/csrf-cookie',

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,0 +1,6 @@
+import { useState } from '#app'
+import { Auth } from '../types'
+
+export function useAuth () {
+  return useState('auth').value as Auth
+}

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -7,7 +7,7 @@ import {
   // @ts-ignore
 } from '#app'
 import { FetchOptions, FetchRequest, ofetch } from 'ofetch'
-import { ModuleOptions, Auth, Callback } from '../types'
+import { ModuleOptions, Auth, Callback, Csrf } from '../types'
 
 export default defineNuxtPlugin(async () => {
   const auth = useState<Auth>('auth', () => {
@@ -53,7 +53,7 @@ export default defineNuxtPlugin(async () => {
     return fetch(endpoint, options)
   }
 
-  async function csrf(): Promise<void> {
+  async function csrf (): Csrf {
     await ofetch(config.endpoints.csrf, {
       baseURL: config.baseUrl,
       credentials: 'include',
@@ -76,7 +76,7 @@ export default defineNuxtPlugin(async () => {
     useCookie('nuxt-sanctum-auth-token').value = null
   }
 
-  async function getUser<T>(): Promise<T | undefined> {
+  async function getUser<T> (): Promise<T | undefined> {
     if (auth.value.loggedIn && auth.value.user) {
       return auth.value.user as T
     }
@@ -93,7 +93,7 @@ export default defineNuxtPlugin(async () => {
     }
   }
 
-  async function login(
+  async function login (
     data: any,
     callback?: Callback | undefined
   ): Promise<void> {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -6,43 +6,52 @@ import {
   useCookie
   // @ts-ignore
 } from '#app'
-import { ofetch } from 'ofetch'
+import { FetchOptions, FetchRequest, ofetch } from 'ofetch'
 import { ModuleOptions, Auth, Callback } from '../types'
 
 export default defineNuxtPlugin(async () => {
   const auth = useState<Auth>('auth', () => {
     return {
       user: null,
-      loggedIn: false
+      loggedIn: false,
+      token: null
     }
   })
 
   const config: ModuleOptions = useRuntimeConfig().nuxtSanctumAuth
 
-  addRouteMiddleware('auth', async () => {
+  addRouteMiddleware('fetch-user', async () => {
+    getToken()
+
     await getUser()
 
+  }, { global: true })
+
+  addRouteMiddleware('auth', async () => {
     if (auth.value.loggedIn === false) {
       return config.redirects.login
     }
   })
 
   addRouteMiddleware('guest', async () => {
-    await getUser()
-
     if (auth.value.loggedIn) {
       return config.redirects.home
     }
   })
 
-  const apiFetch = ofetch.create({
-    baseURL: config.baseUrl,
-    credentials: 'include',
-    headers: {
-      Accept: 'application/json',
-      'X-XSRF-TOKEN': useCookie('XSRF-TOKEN').value
-    } as HeadersInit
-  })
+  const apiFetch = (endpoint: FetchRequest, options?: FetchOptions) => {
+    const fetch = ofetch.create({
+      baseURL: config.baseUrl,
+      credentials: 'include',
+      headers: {
+        Accept: 'application/json',
+        'X-XSRF-TOKEN': !config.token ? useCookie('XSRF-TOKEN').value : null,
+        'Authorization': config.token ? 'Bearer ' + auth.value.token : null
+      } as HeadersInit
+    })
+
+    return fetch(endpoint, options)
+  }
 
   async function csrf(): Promise<void> {
     await ofetch(config.endpoints.csrf, {
@@ -53,6 +62,18 @@ export default defineNuxtPlugin(async () => {
         Accept: 'application/json'
       }
     })
+  }
+
+  const getToken = () => {
+    auth.value.token = useCookie('nuxt-sanctum-auth-token').value
+  }
+
+  const setToken = (token: string) => {
+    useCookie('nuxt-sanctum-auth-token').value = token
+  }
+
+  const clearToken = () => {
+    useCookie('nuxt-sanctum-auth-token').value = null
   }
 
   async function getUser<T>(): Promise<T | undefined> {
@@ -76,7 +97,10 @@ export default defineNuxtPlugin(async () => {
     data: any,
     callback?: Callback | undefined
   ): Promise<void> {
-    await csrf()
+
+    if (!config.token) {
+      await csrf()
+    }
 
     try {
       const response = await apiFetch<Response>(config.endpoints.login, {
@@ -84,9 +108,14 @@ export default defineNuxtPlugin(async () => {
         body: JSON.stringify(data),
         headers: {
           Accept: 'application/json',
-          'X-XSRF-TOKEN': useCookie('XSRF-TOKEN').value
+          'X-XSRF-TOKEN': !config.token ? useCookie('XSRF-TOKEN').value : null,
+          'Authorization': config.token ? 'Bearer ' + auth.value.token : null
         } as HeadersInit
       })
+
+      if (config.token && response) {
+        setToken(response.token)
+      }
 
       if (callback !== undefined) {
         callback(response)
@@ -114,6 +143,8 @@ export default defineNuxtPlugin(async () => {
     } finally {
       auth.value.loggedIn = false
       auth.value.user = null
+      auth.value.token = null
+      clearToken()
     }
   }
 

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -103,7 +103,7 @@ export default defineNuxtPlugin(async () => {
     }
 
     try {
-      const response = await apiFetch<Response>(config.endpoints.login, {
+      const response = await apiFetch(config.endpoints.login, {
         method: 'POST',
         body: JSON.stringify(data),
         headers: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { FetchOptions, FetchRequest } from 'ofetch'
+
 export interface Endpoints {
   csrf: string
   login: string
@@ -24,4 +26,38 @@ export interface Auth {
   token: string | null
 }
 
+export type ApiFetch = (endpoint: FetchRequest, options?: FetchOptions) => Promise<void>
+
+export type Csrf = Promise<void>
+
 export type Callback = (response: any) => void
+
+export interface SanctumAuthPlugin {
+  login: (data: any, callback?: Callback | undefined) => Promise<void>
+  logout: (callback?: Callback | undefined) => Promise<void>
+  getUser<T> (): Promise<T | undefined>
+}
+
+// @ts-ignore
+declare module 'vue/types/vue' {
+  interface Vue {
+    $sanctumAuth: SanctumAuthPlugin
+  }
+}
+
+// Nuxt Bridge & Nuxt 3
+declare module '#app' {
+  interface NuxtApp extends PluginInjection {
+  }
+}
+
+interface PluginInjection {
+  $sanctumAuth: SanctumAuthPlugin
+  apiFetch: ApiFetch,
+  csrf: Csrf,
+}
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties extends PluginInjection {
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Redirects {
 }
 
 export interface ModuleOptions {
+  token: boolean
   baseUrl: string
   endpoints: Endpoints
   redirects: Redirects
@@ -20,6 +21,7 @@ export interface ModuleOptions {
 export interface Auth {
   user: any | null
   loggedIn: boolean
+  token: string | null
 }
 
 export type Callback = (response: any) => void


### PR DESCRIPTION
Solves #7 
Added `token` boolean property to module options, to switch between sanctum cookie-based to jwt-based auth (a-là mobile app frontend). See [laravel docs](https://laravel.com/docs/10.x/sanctum#issuing-mobile-api-tokens)

With jwt mode:

- At login time, the plugin expects a json response from laravel backend containing the token generated ([guide](https://laravel.com/docs/10.x/sanctum#issuing-mobile-api-tokens))
- Once token is received,  it is saved in a cookie
- A global middleware that runs for every route obtains the cookie token and fetches again the user (if app store is empty, just like the standard mode)
- The token is added in the headers of every request made using `apiFetch` function (again, just like the standard mode)

Configuration and steps needed are in readme file.