### PR TITLE
Added ability to add custom CSRF keys

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -10,6 +10,10 @@ const defaults: ModuleOptions = {
     logout: '/logout',
     user: '/user'
   },
+  csrf: {
+    headerKey: 'X-XSRF-TOKEN',
+    cookieKey: 'XSRF-TOKEN',
+  },
   redirects: {
     home: '/',
     login: '/login',

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -40,12 +40,13 @@ export default defineNuxtPlugin(async () => {
   })
 
   const apiFetch = (endpoint: FetchRequest, options?: FetchOptions) => {
+
     const fetch = ofetch.create({
       baseURL: config.baseUrl,
       credentials: 'include',
       headers: {
         Accept: 'application/json',
-        'X-XSRF-TOKEN': !config.token ? useCookie('XSRF-TOKEN').value : null,
+        [config.csrf.headerKey]: !config.token ? useCookie(config.csrf.cookieKey).value : null,
         'Authorization': config.token ? 'Bearer ' + auth.value.token : null
       } as HeadersInit
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface Redirects {
 }
 
 export interface ModuleOptions {
+  csrf: CSRFSpec
   token: boolean
   baseUrl: string
   endpoints: Endpoints
@@ -24,6 +25,11 @@ export interface Auth {
   user: any | null
   loggedIn: boolean
   token: string | null
+}
+
+export interface CSRFSpec {
+  headerKey: string,
+  cookieKey: string,
 }
 
 export type ApiFetch = (endpoint: FetchRequest, options?: FetchOptions) => Promise<void>


### PR DESCRIPTION
Hey, I've come across an issue with hosting two Laravel apps on two different subdomains which is setting the XSRF-TOKEN cookie over two different subdomains ([described in more detail here](https://laracasts.com/discuss/channels/laravel/using-sanctum-on-multiple-subdomains-with-xsrf-token-cookie?page=1)).

As a result, I've taken the idea from the responses of the above thread to set a custom name for the CSRF token on one of the Laravel apps (XSRF-TOKEN-PORTAL) and set the header that the frontend sends to X-XSRF-TOKEN-PORTAL.

I've created a branch to allow the user to set a custom CSRF key for the header, and a custom cookie key value.

Hopefully this is useful!