### PR TITLE
$apiFetch promise returns dynamic type instead of void

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,10 @@ export interface CSRFSpec {
   tokenCookieKey: string
 }
 
-export type ApiFetch = (
+export type ApiFetch = <T>(
   endpoint: FetchRequest,
   options?: FetchOptions
-) => Promise<void>
+) => Promise<T>
 
 export type Csrf = Promise<void>
 


### PR DESCRIPTION
Fixed ApiFetch type, now returning Promise<T> instead of Promise<void>. This way main project can declare type returned by the promise dynamically.
Example:
```typescript
const fetchTest = async () => {
        // we now can define response type MyType 
        const response : MyType = await $apiFetch(`backend.test/api/test`, {
            method: 'GET'
        })
        // ...
    }
```