### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,4 +1,4 @@
-import { useState } from '#app'
+import { useState } from '#imports'
 import { Auth } from '../types'
 
 export function useAuth () {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -5,7 +5,7 @@ import {
   useRuntimeConfig,
   useCookie
   // @ts-ignore
-} from '#app'
+} from '#imports'
 import { FetchOptions, FetchRequest, ofetch } from 'ofetch'
 import { ModuleOptions, Auth, Callback, Csrf } from '../types'
 


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.